### PR TITLE
Many changes:

### DIFF
--- a/debugger/HaxeProtocol.hx
+++ b/debugger/HaxeProtocol.hx
@@ -122,8 +122,8 @@ class HaxeProtocol
         }
         
         // Validate the length.  Don't allow messages larger than
-        // 100K.
-        if (msg_len > (100 * 1024)) {
+        // 2 MB.
+        if (msg_len > (2 * 1024 * 1024)) {
             throw "Read bad message length: " + msg_len + ".";
         }
         
@@ -132,7 +132,7 @@ class HaxeProtocol
     }
 
     private static var gClientIdentification = 
-        "Haxe debug client v1.0 coming at you!\n\n";
+        "Haxe debug client v1.1 coming at you!\n\n";
     private static var gServerIdentification = 
-        "Haxe debug server v1.0 ready and willing, sir!\n\n";
+        "Haxe debug server v1.1 ready and willing, sir!\n\n";
 }


### PR DESCRIPTION
- Made the Classes command return a paged request that fetches a subset of
  all classes; necessary to allow IntelliJ to read the whole list of classes
  when there are many classes by fetching them page by page
- Added an AllClasses command to get all classes in one go, which is equivalent
  to the old Classes command, and updated the command line controller to use
  AllClasses
- Changed the response message for FilesFullPath to be a Files value instead of
  the previously-added FilesFullPath message, since the FilesFullPath message was
  identical in nature to the already existing and now re-used Files message
- Changed CurrentThread message to ThreadLocation to be more explicit and added
  some additional data to it to allow IntelliJ Haxe plugin to have all of the
  data it needs to show thread status
- Support a new GetStructured request with a Structured response that gets a
  structured version of the value instead of a textual version, that allows for
  IDE style data displays
- Fixed parsing of class:function breakpoints in command line controller
- Allow file:line breakpoints to be handled separately and to work properly
  in command line controller
- Fixed command line controller parsing of some commands
- Fixed documentation of filespath command
- Allow up to 2 MB messages to support big projects
- Fix a deadlock bug when setting current thread
- Simplified the return types of some Commands to OK where no useful data was
  being returned in the previously more specific responses
- Add some more detail to error messages
- Fix some reflection logic to fix some data evaluation bugs
- Bumped debugger protocol version to 1.1 to reflect changes
- Allow HaxeServer class to specify the IP address to listen on as well as the
  port, to ensure that remote processes can attach to the debugger